### PR TITLE
Add Rebel-readline support to Figwheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ pom.xml
 .cpcache/
 resources/
 .DS_Store
+.rebel_readline_history

--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ This is an attempt at creating a skeleton project using [Figwheel](https://githu
 
 0. Install [Clojure](https://clojure.org/guides/getting_started).
 1. Download the code in this repo.
-2. From wherever you downloaded it, run `clj build.clj figwheel`.
+2. From wherever you downloaded it, run `clojure build.clj figwheel`. (Since figwheel uses rebel, a readline is already supplied, so we use `clojure` instead of `clj`.)
 3. Attach to the web app on [localhost:3449](http://localhost:3449)

--- a/deps.edn
+++ b/deps.edn
@@ -1,18 +1,20 @@
 {:paths ["src" "dev" "resources"]
  :deps
- {org.clojure/clojure       {:mvn/version "1.9.0"}
+ {org.clojure/clojure             {:mvn/version "1.9.0"}
 
   ;; For Spec
-  org.clojure/test.check    {:mvn/version "0.9.0"}
+  org.clojure/test.check          {:mvn/version "0.9.0"}
 
   ;; ClojureScript
-  org.clojure/clojurescript {:mvn/version "1.9.946"}
-  com.cemerick/piggieback   {:mvn/version "0.2.2" :exclusions
-                             [com.google.javascript/closure-compiler]}
-  figwheel-sidecar          {:mvn/version "0.5.15" :exclusions
-                             [com.google.javascript/closure-compiler]}
+  org.clojure/clojurescript       {:mvn/version "1.9.946"}
+  com.cemerick/piggieback         {:mvn/version "0.2.2" :exclusions
+                                   [com.google.javascript/closure-compiler]}
+  figwheel-sidecar                {:mvn/version "0.5.15" :exclusions
+                                   [com.google.javascript/closure-compiler]}
 
   ;; REPL
-  org.clojure/tools.nrepl   {:mvn/version "0.2.12"}
-  cider/cider-nrepl         {:mvn/version "0.16.0"}
-  refactor-nrepl            {:mvn/version "2.3.1"}}}
+  org.clojure/tools.nrepl         {:mvn/version "0.2.12"}
+  cider/cider-nrepl               {:mvn/version "0.16.0"}
+  refactor-nrepl                  {:mvn/version "2.3.1"}
+  com.bhauman/rebel-readline      {:mvn/version "0.1.2"}
+  com.bhauman/rebel-readline-cljs {:mvn/version "0.1.2"}}}


### PR DESCRIPTION
Figwheel will automatically take advantage of it, if available as a dep.

NB: when using rebel, we should use `clojure` over `clj`, since
`clj` will wrap with another readline program.
(See https://github.com/bhauman/rebel-readline/tree/master/rebel-readline-cljs)